### PR TITLE
[WIP] Write interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+
+
+
+# Engine
+
+## Traces
+
+## Operations
+
+Composite types implement any number of operations as functions.
+
+These functions strictly accept and return IPLD Data Model kinds.
+
+In JS, these functions take two arguments, both of which are Maps: `args` and `continuation`.
+
+These functions return JS objects with a variety of signatures. 
+
+#### `{ result: Kind }`
+
+
+### Calling operations on other data structures
+
+
+
+#### `{ call: { path: String, method: String, args: Map, continuation: Map } }`
+
+#### `{ call: { target: Kind, method: String, args: Map, continuation: Map } }`
+
+#### `{ calls: List of calls }`
+
+### Creating blocks
+
+#### `{ make: { source: Kind }, continuation: Map }`
+
+#### `{ make: { raw: Bytes }, continuation: Map }`

--- a/src/bytes/fixed-chunker.js
+++ b/src/bytes/fixed-chunker.js
@@ -58,7 +58,7 @@ class FixedChunker extends Node {
       return { continuation, make: { source: { _type, length, chunkSize, data } } }   
     }
     if (continuation.state === 'final') {
-      return { result: continuation.make.cid }
+      return { result: { cid: continuation.make.cid } }
     }
     let i = continuation.i
     let cids = continuation.cids

--- a/src/bytes/fixed-chunker.js
+++ b/src/bytes/fixed-chunker.js
@@ -43,7 +43,7 @@ class FixedChunker extends Node {
     let inlineListMax = args.inlineListMax || 100
     if (this.data) {
       if (this.data.chunkSize) chunkSize = this.data.chunkSize
-      if (this.data.inlineListMax) inlineListMax = this.data.inlineListMax   
+      if (this.data.inlineListMax) inlineListMax = this.data.inlineListMax
     }
     if (!continuation) {
       continuation = { i: 0, cids: [] }
@@ -55,16 +55,16 @@ class FixedChunker extends Node {
     if (continuation.state === 'list') {
       let data = continuation.make.cid
       continuation.state = 'final'
-      return { continuation, make: { source: { _type, length, chunkSize, data } } }   
+      return { continuation, make: { source: { _type, length, chunkSize, data } } }
     }
     if (continuation.state === 'final') {
       return { result: { cid: continuation.make.cid } }
     }
     let i = continuation.i
     let cids = continuation.cids
-    
+
     if (i < source.length) {
-      continuation.state = 'chunk' 
+      continuation.state = 'chunk'
       return { continuation, make: { raw: source.slice(i, i + chunkSize) } }
     }
     if (cids.length > inlineListMax) {
@@ -76,7 +76,7 @@ class FixedChunker extends Node {
       return { continuation, call }
     }
     continuation.state = 'final'
-    return { continuation, make: { source: { _type, length, chunkSize, data: cids } } } 
+    return { continuation, make: { source: { _type, length, chunkSize, data: cids } } }
   }
 }
 FixedChunker.create = async function * (source, chunkSize = 1024, codec = 'dag-json', createList = null) {

--- a/src/index.js
+++ b/src/index.js
@@ -54,9 +54,9 @@ const system = async function * (opts, target, info) {
       let origin = target
 
       /* resolve local path lookup for target */
-      if (typeof call.target === 'string') {
+      if (call.path) {
         let last
-        let _getcall = { method: 'get', args: { path: call.target }, local: true }
+        let _getcall = { method: 'get', args: { path: call.path }, local: true }
         for await (let trace of system(opts, new MapKind(origin.data), _getcall)) {
           last = trace
           yield trace

--- a/src/index.js
+++ b/src/index.js
@@ -53,10 +53,10 @@ const system = async function * (opts, target, info) {
       else if (_make.source) {
         block = Block.encoder(_make.source, opts.codec || defaultCodec)
       } else {
-        throw new Error("Make must provide source or raw")
-      } 
+        throw new Error('Make must provide source or raw')
+      }
       // TODO: envelopes for encryption
-      yield { trace: make, block, origin: _make}
+      yield { trace: 'make', block, origin: _make }
       let cid = await block.cid()
       info.continuation = _make.info.continuation || {}
       info.continuation.cid = cid

--- a/src/links/path.js
+++ b/src/links/path.js
@@ -14,6 +14,11 @@ class PathLink extends Node {
   resolve (args) {
     return { call: mkcall(this.data.cid, this.data.path) }
   }
+  create (args) {
+    let cid = args.cid
+    let path = args.path
+    return { make: { source: { _type, cid, path }, proxy: true } }
+  }
 }
 PathLink.create = (cid, path, codec = 'dag-json') => {
   return Block.encoder({ _type, cid, path }, codec)

--- a/src/lists/max-length.js
+++ b/src/lists/max-length.js
@@ -28,6 +28,59 @@ class MaxLengthList extends Node {
       seen += m
     }
   }
+  create (args, continuation = {}) {
+    let values = args.values
+    let maxLength = args.maxLength
+    continuation = Object.assign({}, continuation)
+    continuation.values = values.slice()
+    continuation.parts = continuation.parts || []
+    let size = Math.ceil(len / maxLength)
+    
+    if (continuation.state === 'finish') {
+      return { result: { cid: continuation.cid, len: continuation.len } }
+    }
+    
+    if (continuation.state === 'subcreate') {
+      continuation.parts.push({
+        cid: continuation.result.cid,
+        len: continuation.result.len
+      })
+    }
+    if (continuation.state === 'make') {
+      continuation.parts.push({
+        cid: continuation.cid,
+        len: continuation.len
+      })
+    }
+    if (size > maxLength) {
+      let _args = { values: continuation.values.splice(0, size), maxLength }
+      let _continuation = { state: 'subcreate' }
+      return { call: { 
+        target: this.data, 
+        method: 'create', 
+        args: _args, 
+        continuation: _continuation 
+      } }
+    } else {
+      if (continuation.values.length) {
+        let data = continuation.values.splice(0, size)
+        let source = { _type, data, length: data.length, leaf: true }
+        continuation.state = 'make'
+        continuation.len = data.length
+        return { make: { source }, continuation }  
+      } else {
+        // finish
+        let lengthMap = continuation.parts.map(o => o.len)
+        let data = continuation.parts.map(o => o.cid)
+        continuation.state = 'finish'
+        continuation.len = len
+        return { make: 
+          source: { _type, data, lengthMap, length: len, maxLength },
+          continuation 
+        }       
+      }
+    }
+  }
 }
 MaxLengthList._type = _type
 MaxLengthList.create = async function * (values, maxLength, codec = 'dag-json') {

--- a/src/lists/max-length.js
+++ b/src/lists/max-length.js
@@ -30,16 +30,17 @@ class MaxLengthList extends Node {
   }
   create (args, continuation = {}) {
     let values = args.values
+    let len = values.length
     let maxLength = args.maxLength
     continuation = Object.assign({}, continuation)
     continuation.values = values.slice()
     continuation.parts = continuation.parts || []
     let size = Math.ceil(len / maxLength)
-    
+
     if (continuation.state === 'finish') {
       return { result: { cid: continuation.cid, len: continuation.len } }
     }
-    
+
     if (continuation.state === 'subcreate') {
       continuation.parts.push({
         cid: continuation.result.cid,
@@ -55,11 +56,11 @@ class MaxLengthList extends Node {
     if (size > maxLength) {
       let _args = { values: continuation.values.splice(0, size), maxLength }
       let _continuation = { state: 'subcreate' }
-      return { call: { 
-        target: this.data, 
-        method: 'create', 
-        args: _args, 
-        continuation: _continuation 
+      return { call: {
+        target: this.data,
+        method: 'create',
+        args: _args,
+        continuation: _continuation
       } }
     } else {
       if (continuation.values.length) {
@@ -67,17 +68,19 @@ class MaxLengthList extends Node {
         let source = { _type, data, length: data.length, leaf: true }
         continuation.state = 'make'
         continuation.len = data.length
-        return { make: { source }, continuation }  
+        return { make: { source }, continuation }
       } else {
         // finish
         let lengthMap = continuation.parts.map(o => o.len)
         let data = continuation.parts.map(o => o.cid)
         continuation.state = 'finish'
         continuation.len = len
-        return { make: 
-          source: { _type, data, lengthMap, length: len, maxLength },
-          continuation 
-        }       
+        return {
+          make: {
+            source: { _type, data, lengthMap, length: len, maxLength }
+          },
+          continuation
+        }
       }
     }
   }

--- a/src/lists/max-length.js
+++ b/src/lists/max-length.js
@@ -22,7 +22,7 @@ class MaxLengthList extends Node {
       let m = this.data.lengthMap[i]
       if (attr < (seen + m)) {
         path = (attr - seen) + path.join('/')
-        return { call: { target: 'data/' + i, info: { method: 'get', args: { path } }, proxy: true } }
+        return { call: { path: 'data/' + i, info: { method: 'get', args: { path } }, proxy: true } }
       }
       i++
       seen += m

--- a/test/list.max-length.spec.js
+++ b/test/list.max-length.spec.js
@@ -3,7 +3,7 @@ const Block = require('@ipld/block')
 const assert = require('assert')
 const tsame = require('tsame')
 const MaxLengthList = require('../src/lists/max-length')
-const { Lookup, get } = require('../')
+const { Lookup, get, create } = require('../')
 const getPath = get
 
 const same = (...args) => assert.ok(tsame(...args))
@@ -38,13 +38,11 @@ lookup.register(MaxLengthList._type, MaxLengthList)
 let fixture = Array.from({ length: 107 }).map((v, k) => Buffer.from('hello world: ' + k))
 
 test('basic create', async () => {
+  let { get, put } = storage()
+  let opts = { lookup, get, put }
   let blocks = fixture.map(b => Block.encoder(b, 'raw'))
-  let cids = await Promise.all(blocks.map(b => b.cid()))
-  let iter = MaxLengthList.create(cids, 3)
-  let trace = await asyncList(iter)
-  for (let block of trace) {
-    assert.ok(block.decode().data.length < 4)
-  }
+  let values = await Promise.all(blocks.map(b => b.cid()))
+  let root = await create(opts, MaxLengthList._type, { values, maxLength: 3 })
 })
 
 test('basic gets', async () => {


### PR DESCRIPTION
This isn’t ready but I’m starting to make some other API changes along the way and wanted to surface them sooner rather than later.

@rvagg Calls that use a path as the `target` have to do so explicitly now, with `path` rather than `target`.