### PR TITLE
feat: add Vector type (via iavector)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "@ipld/block": "^2.0.3",
     "cids": "^0.7.1",
-    "class-is": "^1.1.0"
+    "class-is": "^1.1.0",
+    "iavector": "0.0.0"
   },
   "devDependencies": {
     "mocha": "^6.1.4",

--- a/src/lists/vector.js
+++ b/src/lists/vector.js
@@ -14,7 +14,7 @@ class Vector extends Node {
     let index = parseInt(path.shift(), 10)
 
     if (!Number.isInteger(index)) {
-      throw new Error('Vector type can only look up integers ' + index + ', ' + args)
+      throw new Error('Vector type can only look up integers')
     }
 
     let traversal = iavector.traverseGetOne(this.data, index)
@@ -42,9 +42,9 @@ Vector._type = _type
 
 async function * runConstruction (construction, codec) {
   while (true) {
-    let c = 0
+    let isConstructed = false
     for (let node of construction.construct()) {
-      c++
+      isConstructed = true
       let serializable = node.toSerializable()
       serializable._type = Vector._type
       let block = Block.encoder(serializable, codec)
@@ -52,7 +52,7 @@ async function * runConstruction (construction, codec) {
       node.id = await block.cid()
       construction.saved(node)
     }
-    if (c === 0) {
+    if (!isConstructed) {
       break
     }
   }

--- a/src/lists/vector.js
+++ b/src/lists/vector.js
@@ -1,0 +1,74 @@
+const Node = require('../base')
+const iavector = require('iavector')
+const Block = require('@ipld/block')
+
+const _type = 'IPLD/Experimental/Vector/0'
+
+class Vector extends Node {
+  get _type () {
+    return _type
+  }
+
+  get (args) {
+    let path = args.path.split('/').filter(Boolean)
+    let index = parseInt(path.shift(), 10)
+
+    if (!Number.isInteger(index)) {
+      throw new Error('Vector type can only look up integers ' + index + ', ' + args)
+    }
+
+    let traversal = iavector.traverseGetOne(this.data, index)
+
+    if (!traversal) {
+      throw new Error(`Vector does not contain index`)
+    }
+
+    if (traversal.value) {
+      if (!path.length) {
+        return { result: traversal.value }
+      }
+      // user wants to go deeper into returned object
+      let info = { method: 'get', args: { path: path.join('/') } }
+      let call = { info, target: traversal.value, proxy: true }
+      return { call }
+    }
+
+    path = `${traversal.nextIndex}/${path.join('/')}`
+    return { call: { target: traversal.nextId, info: { method: 'get', args: { path } }, proxy: true } }
+  }
+}
+
+Vector._type = _type
+
+async function * runConstruction (construction, codec) {
+  while (true) {
+    let c = 0
+    for (let node of construction.construct()) {
+      c++
+      let serializable = node.toSerializable()
+      serializable._type = Vector._type
+      let block = Block.encoder(serializable, codec)
+      yield block
+      node.id = await block.cid()
+      construction.saved(node)
+    }
+    if (c === 0) {
+      break
+    }
+  }
+}
+
+Vector.create = async function * create (from, width = 256, codec = 'dag-json') {
+  let construction = iavector.constructFrom(from, width)
+  yield * runConstruction(construction, codec)
+}
+
+/* WIP: Experimenting with mutation interface
+
+Vector.append = async function * append (block, value, codec = 'dag-json') {
+  let construction = iavector.constructAppend(block, value)
+  yield * runConstruction(construction, codec)
+}
+*/
+
+module.exports = Vector

--- a/src/lists/vector.js
+++ b/src/lists/vector.js
@@ -11,13 +11,13 @@ class Vector extends Node {
 
   get (args) {
     let path = args.path.split('/').filter(Boolean)
-    let index = parseInt(path.shift(), 10)
+    const index = parseInt(path.shift(), 10)
 
     if (!Number.isInteger(index)) {
       throw new Error('Vector type can only look up integers')
     }
 
-    let traversal = iavector.traverseGetOne(this.data, index)
+    const traversal = iavector.traverseGetOne(this.data, index)
 
     if (!traversal) {
       throw new Error(`Vector does not contain index`)
@@ -28,8 +28,8 @@ class Vector extends Node {
         return { result: traversal.value }
       }
       // user wants to go deeper into returned object
-      let info = { method: 'get', args: { path: path.join('/') } }
-      let call = { info, target: traversal.value, proxy: true }
+      const info = { method: 'get', args: { path: path.join('/') } }
+      const call = { info, target: traversal.value, proxy: true }
       return { call }
     }
 
@@ -45,9 +45,9 @@ async function * runConstruction (construction, codec) {
     let isConstructed = false
     for (let node of construction.construct()) {
       isConstructed = true
-      let serializable = node.toSerializable()
+      const serializable = node.toSerializable()
       serializable._type = Vector._type
-      let block = Block.encoder(serializable, codec)
+      const block = Block.encoder(serializable, codec)
       yield block
       node.id = await block.cid()
       construction.saved(node)
@@ -59,14 +59,14 @@ async function * runConstruction (construction, codec) {
 }
 
 Vector.create = async function * create (from, width = 256, codec = 'dag-json') {
-  let construction = iavector.constructFrom(from, width)
+  const construction = iavector.constructFrom(from, width)
   yield * runConstruction(construction, codec)
 }
 
 /* WIP: Experimenting with mutation interface
 
 Vector.append = async function * append (block, value, codec = 'dag-json') {
-  let construction = iavector.constructAppend(block, value)
+  const construction = iavector.constructAppend(block, value)
   yield * runConstruction(construction, codec)
 }
 */

--- a/test/list.vector.spec.js
+++ b/test/list.vector.spec.js
@@ -19,14 +19,6 @@ function storage () {
   }
 }
 
-async function asyncList (iter) {
-  let parts = []
-  for await (let part of iter) {
-    parts.push(part)
-  }
-  return parts
-}
-
 const lookup = new Lookup()
 lookup.register(Vector._type, Vector)
 
@@ -41,9 +33,8 @@ describe('Vector', () => {
 
   it('create with CID values', async () => {
     let iter = Vector.create(cids, 3)
-    let trace = await asyncList(iter)
     let valueCount = 0
-    for (let block of trace) {
+    for await (let block of iter) {
       let d = block.decode()
       assert.ok(d.data.length <= 3)
       if (d.height === 0) {
@@ -55,9 +46,8 @@ describe('Vector', () => {
 
   it('create with inline values', async () => {
     let iter = Vector.create(fixture, 32)
-    let trace = await asyncList(iter)
     let valueCount = 0
-    for (let block of trace) {
+    for await (let block of iter) {
       let d = block.decode()
       assert.ok(d.data.length <= 32)
       if (d.height === 0) {

--- a/test/list.vector.spec.js
+++ b/test/list.vector.spec.js
@@ -23,8 +23,8 @@ const lookup = new Lookup()
 lookup.register(Vector._type, Vector)
 
 describe('Vector', () => {
-  let fixture = Array.from({ length: 301 }).map((v, i) => { return { leafValue: `v${i}` } })
-  let blocks = fixture.map(b => Block.encoder(b, 'dag-cbor'))
+  const fixture = Array.from({ length: 301 }).map((v, i) => { return { leafValue: `v${i}` } })
+  const blocks = fixture.map(b => Block.encoder(b, 'dag-cbor'))
   let cids
 
   before(async () => {
@@ -32,33 +32,33 @@ describe('Vector', () => {
   })
 
   it('create with CID values', async () => {
-    let iter = Vector.create(cids, 3)
+    const iter = Vector.create(cids, 3)
     let valueCount = 0
     for await (let block of iter) {
-      let d = block.decode()
-      assert.ok(d.data.length <= 3)
-      if (d.height === 0) {
-        valueCount += d.data.length
+      const decoded = block.decode()
+      assert.ok(decoded.data.length <= 3)
+      if (decoded.height === 0) {
+        valueCount += decoded.data.length
       }
     }
     assert.strictEqual(valueCount, 301)
   })
 
   it('create with inline values', async () => {
-    let iter = Vector.create(fixture, 32)
+    const iter = Vector.create(fixture, 32)
     let valueCount = 0
     for await (let block of iter) {
-      let d = block.decode()
-      assert.ok(d.data.length <= 32)
-      if (d.height === 0) {
-        valueCount += d.data.length
+      const decoded = block.decode()
+      assert.ok(decoded.data.length <= 32)
+      if (decoded.height === 0) {
+        valueCount += decoded.data.length
       }
     }
     assert.strictEqual(valueCount, 301)
   })
 
   it('gets with CID values', async () => {
-    let store = storage()
+    const store = storage()
     await Promise.all(blocks.map(b => store.put(b)))
     let root
     for await (let block of Vector.create(cids, 3)) {
@@ -79,7 +79,7 @@ describe('Vector', () => {
   })
 
   it('gets with inline values', async () => {
-    let store = storage()
+    const store = storage()
     let root
     for await (let block of Vector.create(fixture, 32)) {
       root = block
@@ -87,7 +87,7 @@ describe('Vector', () => {
     }
 
     let result = await getPath(store, root, '0/leafValue')
-    let buffer = result.data
+    const buffer = result.data
     assert.strictEqual(buffer.toString(), 'v0')
 
     result = await getPath(store, root, '101/leafValue')

--- a/test/list.vector.spec.js
+++ b/test/list.vector.spec.js
@@ -1,0 +1,109 @@
+/* eslint-env mocha */
+
+const Block = require('@ipld/block')
+const assert = require('assert')
+const Vector = require('../src/lists/vector')
+const { Lookup, get } = require('../')
+const getPath = get
+
+function storage () {
+  let kv = new Map()
+  return {
+    async put (block) {
+      return kv.set((await block.cid()).toString(), block)
+    },
+    get (cid) {
+      return kv.get(cid.toString())
+    },
+    lookup // so we can pass to get()
+  }
+}
+
+async function asyncList (iter) {
+  let parts = []
+  for await (let part of iter) {
+    parts.push(part)
+  }
+  return parts
+}
+
+const lookup = new Lookup()
+lookup.register(Vector._type, Vector)
+
+describe('Vector', () => {
+  let fixture = Array.from({ length: 301 }).map((v, i) => { return { leafValue: `v${i}` } })
+  let blocks = fixture.map(b => Block.encoder(b, 'dag-cbor'))
+  let cids
+
+  before(async () => {
+    cids = await Promise.all(blocks.map(b => b.cid()))
+  })
+
+  it('create with CID values', async () => {
+    let iter = Vector.create(cids, 3)
+    let trace = await asyncList(iter)
+    let valueCount = 0
+    for (let block of trace) {
+      let d = block.decode()
+      assert.ok(d.data.length <= 3)
+      if (d.height === 0) {
+        valueCount += d.data.length
+      }
+    }
+    assert.strictEqual(valueCount, 301)
+  })
+
+  it('create with inline values', async () => {
+    let iter = Vector.create(fixture, 32)
+    let trace = await asyncList(iter)
+    let valueCount = 0
+    for (let block of trace) {
+      let d = block.decode()
+      assert.ok(d.data.length <= 32)
+      if (d.height === 0) {
+        valueCount += d.data.length
+      }
+    }
+    assert.strictEqual(valueCount, 301)
+  })
+
+  it('gets with CID values', async () => {
+    let store = storage()
+    await Promise.all(blocks.map(b => store.put(b)))
+    let root
+    for await (let block of Vector.create(cids, 3)) {
+      root = block
+      await store.put(block)
+    }
+    let result = await getPath(store, root, '0/leafValue')
+    assert.strictEqual(result.data, 'v0')
+
+    result = await getPath(store, root, '101/leafValue')
+    assert.strictEqual(result.data, 'v101')
+
+    result = await getPath(store, root, '300/leafValue')
+    assert.strictEqual(result.data, 'v300')
+
+    result = await getPath(store, root, '33')
+    assert.deepStrictEqual(result.data, { leafValue: 'v33' })
+  })
+
+  it('gets with inline values', async () => {
+    let store = storage()
+    let root
+    for await (let block of Vector.create(fixture, 32)) {
+      root = block
+      await store.put(block)
+    }
+
+    let result = await getPath(store, root, '0/leafValue')
+    let buffer = result.data
+    assert.strictEqual(buffer.toString(), 'v0')
+
+    result = await getPath(store, root, '101/leafValue')
+    assert.strictEqual(result.data, 'v101')
+
+    result = await getPath(store, root, '300/leafValue')
+    assert.strictEqual(result.data, 'v300')
+  })
+})


### PR DESCRIPTION
Algorithm implemented @ https://github.com/rvagg/iavector

I'm trying to generalise interfaces for traversal and construction so the algorithm can be abstracted into discrete pieces. Traversal for Get and related methods seems to be fairly straightforward as the generalisation seems to work here and in HashMap which are quite different. Construction and mutation is more awkward. I have one here for 'constructFrom' to make a new one from a bare array but my attempts to extend that to an 'constructAppend' have been too messy and I've abandoned a couple of attempts already—I can do it directly on an `IAVector` object, it has a `push()` method, but it's too integrated with saving and loading of blocks to be able to present a clean abstraction here .. so far.